### PR TITLE
Use model class in configuration

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -53,7 +53,7 @@ class DefaultController extends Controller
         $eventPayload = json_decode(Craft::$app->getRequest()->getRawBody());
         $modelClass = StripeWebhooks::$plugin->settings->model;
 
-        $stripeWebhookCall = new StripeWebhookCall([
+        $stripeWebhookCall = new $modelClass([
             'siteId'  => Craft::$app->getSites()->getCurrentSite()->id,
             'type'    => $eventPayload->type ?? '',
             'payload' => json_encode($eventPayload),


### PR DESCRIPTION
The model class from the config is currently not used by the plugin, and this fixes that.